### PR TITLE
add argo vault plugin (AVP)

### DIFF
--- a/kubernetes/aks/apps/argo-apps/kustomization.yaml
+++ b/kubernetes/aks/apps/argo-apps/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # User applications
   - ../finesse/
   - ../nachet/
+  - ../demo/
 
   # System applications
   - ../../system/cert-manager/

--- a/kubernetes/aks/apps/demo/argo-app.yaml
+++ b/kubernetes/aks/apps/demo/argo-app.yaml
@@ -17,6 +17,8 @@ spec:
     repoURL: https://github.com/ai-cfia/howard.git
     path: kubernetes/aks/apps/demo/base
     targetRevision: HEAD
+    plugin:
+      name: argocd-vault-plugin
   syncPolicy:
     automated:
       selfHeal: true

--- a/kubernetes/aks/apps/demo/base/nginx-deployment.yml
+++ b/kubernetes/aks/apps/demo/base/nginx-deployment.yml
@@ -27,6 +27,12 @@ spec:
           image: nginx:1.14.2
           ports:
             - containerPort: 80
+          env:
+            - name: SECRET_ENV_VAR
+              valueFrom:
+                secretKeyRef:
+                  name: nginx-example-secret
+                  key: super-secret
 
 ---
 apiVersion: v1
@@ -70,3 +76,13 @@ spec:
                 name: nginx
                 port:
                   number: 80
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: nginx-example-secret
+  annotations:
+    avp.kubernetes.io/path: "kv/nginx/avp-demo"
+    avp.kubernetes.io/secret-version: "1"
+stringData:
+  super-secret: <super-secret>

--- a/kubernetes/aks/system/argocd/base/secrets.yaml
+++ b/kubernetes/aks/system/argocd/base/secrets.yaml
@@ -1,0 +1,12 @@
+# Commented so that its not applied by argocd. This is a secret that is used by the argocd-vault-plugin. It will be manually created in the argocd namespace.
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: vault-configuration
+#   namespace: argocd
+# data:
+#   VAULT_ADDR: aHR0cDovL3ZhdWx0LnZhdWx0OjgyMDA=
+#   VAULT_TOKEN: <>
+#   AVP_TYPE: dmF1bHQ=
+#   AVP_AUTH_TYPE: dG9rZW4=
+# type: Opaque

--- a/kubernetes/aks/system/argocd/base/secrets.yaml
+++ b/kubernetes/aks/system/argocd/base/secrets.yaml
@@ -8,5 +8,5 @@
 #   VAULT_ADDR: aHR0cDovL3ZhdWx0LnZhdWx0OjgyMDA=
 #   VAULT_TOKEN: <>
 #   AVP_TYPE: dmF1bHQ=
-#   AVP_AUTH_TYPE: dG9rZW4=
+#   AVP_AUTH_TYPE: Z2l0aHVi
 # type: Opaque

--- a/kubernetes/aks/system/argocd/base/vault-plugin-config-map.yaml
+++ b/kubernetes/aks/system/argocd/base/vault-plugin-config-map.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmp-plugin
+  namespace: argocd
+data:
+  avp-helm.yaml: |
+    ---
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: argocd-vault-plugin-helm
+    spec:
+      allowConcurrency: true
+      discover:
+        find:
+          command:
+            - sh
+            - "-c"
+            - "find . -name 'Chart.yaml' && find . -name 'values.yaml'"
+      generate:
+        command:
+          - bash
+          - "-c"
+          - |
+            helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE -f <(echo "$ARGOCD_ENV_HELM_VALUES") . |
+            argocd-vault-plugin generate -s vault-configuration -
+      lockRepo: false
+  avp.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: argocd-vault-plugin
+    spec:
+      allowConcurrency: true
+      discover:
+        find:
+          command:
+            - sh
+            - "-c"
+            - "find . -name '*.yaml' | xargs -I {} grep \"<path\\|avp\\.kubernetes\\.io\" {} | grep ."
+      generate:
+        command:
+          - argocd-vault-plugin
+          - generate
+          - "."
+          - "-s"
+          - "vault-configuration"
+      lockRepo: false

--- a/kubernetes/aks/system/argocd/helm/values.yaml
+++ b/kubernetes/aks/system/argocd/helm/values.yaml
@@ -2250,7 +2250,25 @@ repoServer:
   # -- Additional containers to be added to the repo server pod
   ## Ref: https://argo-cd.readthedocs.io/en/stable/user-guide/config-management-plugins/
   ## Note: Supports use of custom Helm templates
-  extraContainers: []
+  extraContainers:
+    - name: avp-helm
+      command: [/var/run/argocd/argocd-cmp-server]
+      image: quay.io/argoproj/argocd:v2.4.8
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+      volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+        - mountPath: /home/argocd/cmp-server/plugins
+          name: plugins
+        - mountPath: /tmp
+          name: tmp-dir
+        - mountPath: /home/argocd/cmp-server/config
+          name: cmp-plugin
+        - name: custom-tools
+          subPath: argocd-vault-plugin
+          mountPath: /usr/local/bin/argocd-vault-plugin
     # - name: cmp-my-plugin
     #   command:
     #     - "/var/run/argocd/argocd-cmp-server"
@@ -2293,13 +2311,34 @@ repoServer:
     #       name: cmp-tmp
 
   # -- Init containers to add to the repo server pods
-  initContainers: []
+  initContainers:
+    - name: download-tools
+      image: registry.access.redhat.com/ubi8
+      env:
+        - name: AVP_VERSION
+          value: 1.11.0
+      command: [sh, -c]
+      args:
+        - >-
+          curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_amd64 -o argocd-vault-plugin &&
+          chmod +x argocd-vault-plugin &&
+          mv argocd-vault-plugin /custom-tools/
+      volumeMounts:
+        - mountPath: /custom-tools
+          name: custom-tools
 
   # -- Additional volumeMounts to the repo server main container
   volumeMounts: []
 
   # -- Additional volumes to the repo server pod
-  volumes: []
+  volumes:
+    - configMap:
+        name: cmp-plugin
+      name: cmp-plugin
+    - name: custom-tools
+      emptyDir: {}
+    - name: tmp-dir
+      emptyDir: {}
   #  - name: argocd-cmp-cm
   #    configMap:
   #      name: argocd-cmp-cm


### PR DESCRIPTION
This solution provides a new way of handling secrets for our deployments. The [vault plugin for argo](https://argocd-vault-plugin.readthedocs.io/en/stable/howitworks/)  allows to use placeholders inside secrets manifest and give access to a sidecar that can extract sensitive information from our secret manager (Vault) and inject them into our deployments.

TODO 

- [x] update documentation with Vault integration. Done in [pull request](https://github.com/ai-cfia/howard/pull/65).
- [x] Wait until this [pull request](https://github.com/ai-cfia/howard/pull/65) is merged.

closes https://github.com/ai-cfia/howard/issues/110