### PR TITLE
issue #114: find why client_max_body_count is overriden

### DIFF
--- a/kubernetes/aks/apps/nachet/base/nachet-ingress.yaml
+++ b/kubernetes/aks/apps/nachet/base/nachet-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2 # https://kubernetes.github.io/ingress-nginx/examples/rewrite/
-    nginx.ingress.kubernetes.io/client_max_body_size: "200m" # Good value not apply by the system
+    nginx.ingress.kubernetes.io/client_max_body_size: "200m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"

--- a/kubernetes/aks/apps/nachet/base/nachet-ingress.yaml
+++ b/kubernetes/aks/apps/nachet/base/nachet-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2 # https://kubernetes.github.io/ingress-nginx/examples/rewrite/
-    nginx.ingress.kubernetes.io/client_max_body_size: "200m"
+    nginx.ingress.kubernetes.io/client_max_body_size: "200m" # Good value not apply by the system
     nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"

--- a/kubernetes/aks/system/ingress-nginx/helm/values.yaml
+++ b/kubernetes/aks/system/ingress-nginx/helm/values.yaml
@@ -46,7 +46,8 @@ controller:
     http: 80
     https: 443
   # -- Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
-  config: {}
+  config:
+    proxy-body-size: "200m"
   # -- Annotations to be added to the controller config configuration configmap.
   configAnnotations: {}
   # -- Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers
@@ -418,7 +419,7 @@ controller:
         metadata:
           serverAddress: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
           metricName: http_requests_total
-          threshold: '100'
+          threshold: "100"
           query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
 
     behavior: {}

--- a/kubernetes/aks/system/ingress-nginx/helm/values.yaml
+++ b/kubernetes/aks/system/ingress-nginx/helm/values.yaml
@@ -419,7 +419,7 @@ controller:
         metadata:
           serverAddress: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
           metricName: http_requests_total
-          threshold: "100"
+          threshold: '100'
           query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
 
     behavior: {}


### PR DESCRIPTION
The value for client_max_body_count is the good one, but the server is behaving like the value is `1 MB`.

- [ ] Find and fixe the comand that cause the issue