### PR TITLE
Issue #157: OneUpTime Deployment

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,10 +1,7 @@
----
 # Based on https://github.com/kubernetes-sigs/kubespray
 extends: default
-
 ignore: |
   .git/
-
 rules:
   braces:
     min-spaces-inside: 0
@@ -18,3 +15,4 @@ rules:
   line-length: disable
   new-line-at-end-of-file: disable
   truthy: disable
+  document-start: false

--- a/kubernetes/aks/apps/argo-apps/kustomization.yaml
+++ b/kubernetes/aks/apps/argo-apps/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../system/monitoring/
   - ../../system/cloudnativepg/
   - ../../system/vouch-proxy/
+  - ../../system/oneuptime/
 
 patches:
   - patch: |-

--- a/kubernetes/aks/system/oneuptime/argo-app.yaml
+++ b/kubernetes/aks/system/oneuptime/argo-app.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oneuptime
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  destination:
+    namespace: oneuptime
+    server: https://kubernetes.default.svc
+  sources:
+    - chart: oneuptime
+      helm:
+        releaseName: oneuptime
+        valueFiles:
+          - $values/kubernetes/aks/system/monitoring/helm/values.yaml
+      repoURL: https://helm-chart.oneuptime.com
+      targetRevision: 7.0.1978
+    - repoURL: https://github.com/ai-cfia/howard.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/ai-cfia/howard.git
+      path: kubernetes/aks/system/oneuptime/base
+      targetRevision: HEAD
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kubernetes/aks/system/oneuptime/base/ingress.yaml
+++ b/kubernetes/aks/system/oneuptime/base/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oneuptime
+  annotations:
+    # https://oneuptime.com/docs/probe/ip-address
+    nginx.ingress.kubernetes.io/whitelist-source-range: 205.194.32.0/24,51.159.99.250,62.210.173.51,51.159.101.36,172.174.206.132,57.151.99.117
+    external-dns.alpha.kubernetes.io/target: inspection.alpha.canada.ca
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - status.inspection.alpha.canada.ca
+      secretName: status-https-cert
+  rules:
+    - host: status.inspection.alpha.canada.ca
+      http:
+        paths:
+          - path: /
+            backend:
+              service:
+                name: oneuptime-nginx
+                port:
+                  number: 80
+            pathType: Prefix

--- a/kubernetes/aks/system/oneuptime/helm/values.yaml
+++ b/kubernetes/aks/system/oneuptime/helm/values.yaml
@@ -1,0 +1,155 @@
+global:
+  storageClass:
+  clusterDomain: &global-cluster-domain cluster.local
+# Please change this to the domain name / IP where OneUptime server is hosted on.
+host: status.inspection.alpha.canada.ca
+httpProtocol: https
+# (Optional): You usually do not need to set this if you're self hosting. If you do set it, set it to a long random value.
+oneuptimeSecret:
+encryptionSecret:
+# (Optional): You usually do not need to set this if you're self hosting.
+openTelemetryCollectorHost:
+fluentdHost:
+deployment:
+  replicaCount: 1
+metalLb:
+  enabled: false
+  ipAdddressPool:
+    enabled: false
+    addresses:
+    # - 51.158.55.153/32 # List of IP addresses of all the servers in the cluster.
+ingress:
+  service:
+    type: ClusterIP
+    externalIPs:
+    # - 51.158.55.153 # Please make sure this is the same as the one in metalLb.ipAdddressPool.addresses
+postgresql:
+  clusterDomain: *global-cluster-domain
+  auth:
+    username: oneuptime
+    database: oneuptimedb
+  architecture: standalone
+  primary:
+    service:
+      ports:
+        postgresql: "5432"
+    terminationGracePeriodSeconds: 0 # We do this because we do not want to wait for the pod to terminate in case of node failure. https://medium.com/tailwinds-navigator/kubernetes-tip-how-statefulsets-behave-differently-than-deployments-when-node-fails-d29e36bca7d5
+    persistence:
+      size: 25Gi
+  readReplicas:
+    terminationGracePeriodSeconds: 0 # We do this because we do not want to wait for the pod to terminate in case of node failure. https://medium.com/tailwinds-navigator/kubernetes-tip-how-statefulsets-behave-differently-than-deployments-when-node-fails-d29e36bca7d5
+    persistence:
+      size: 25Gi
+clickhouse:
+  clusterDomain: *global-cluster-domain
+  service:
+    ports:
+      http: "8123"
+  shards: 1
+  replicaCount: 1
+  terminationGracePeriodSeconds: 0 # We do this because we do not want to wait for the pod to terminate in case of node failure. https://medium.com/tailwinds-navigator/kubernetes-tip-how-statefulsets-behave-differently-than-deployments-when-node-fails-d29e36bca7d5
+  zookeeper:
+    enabled: false
+  persistence:
+    size: 25Gi
+  auth:
+    username: oneuptime
+  initdbScripts:
+    db-init.sql: |
+      CREATE DATABASE oneuptime;
+redis:
+  clusterDomain: *global-cluster-domain
+  architecture: standalone
+  auth:
+    enabled: true
+  master:
+    persistence:
+      enabled: false # We dont need redis persistence, because we dont do anything with it.
+  replica:
+    persistence:
+      enabled: false # We dont need redis persistence, because we dont do anything with it.
+image:
+  registry: docker.io
+  repository: oneuptime
+  pullPolicy: Always
+  tag: release
+  restartPolicy: Always
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+nodeEnvironment: production
+billing:
+  enabled: false
+  publicKey:
+  privateKey:
+  smsDefaultValueInCents:
+  callDefaultValueInCentsPerMinute:
+  smsHighRiskValueInCents:
+  callHighRiskValueInCentsPerMinute:
+subscriptionPlan:
+  basic:
+  growth:
+  scale:
+  enterprise:
+analytics:
+  host:
+  key:
+internalSmtp:
+  sendingDomain:
+  dkimPrivateKey:
+  dkimPublicKey:
+  email:
+  name:
+incidents:
+  disableAutomaticCreation: false
+statusPage:
+  cnameRecord:
+probes:
+  one:
+    name: "Probe"
+    description: "Probe"
+    monitoringWorkers: 3
+    monitorFetchLimit: 10
+    key:
+    replicaCount: 1
+    # two:
+    #   name: "Probe 2"
+    #   description: "Probe 2"
+    #   monitoringWorkers: 3
+    #   monitorFetchLimit: 10
+    #   key:
+    #   replicaCount: 1
+port:
+  app: 3002
+  ingestor: 3400
+  testServer: 3800
+  accounts: 3003
+  statusPage: 3105
+  dashboard: 3009
+  adminDashboard: 3158
+  nginx: 80
+  haraka: 2525
+  probe: 3500
+  otelCollectorGrpc: 4317
+  otelCollectorHttp: 4318
+  isolatedVM: 4572
+testServer:
+  enabled: false
+openTelemetryExporter:
+  endpoint:
+    server:
+    client:
+  headers:
+    app:
+    dashboard:
+    accounts:
+    statusPage:
+    probe:
+    adminDashboard:
+containerSecurityContext:
+podSecurityContext:
+# This can be one of the following: DEBUG, INFO, WARN, ERROR
+logLevel: ERROR

--- a/kubernetes/aks/system/oneuptime/kustomization.yaml
+++ b/kubernetes/aks/system/oneuptime/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - argo-app.yaml


### PR DESCRIPTION
In order to provide visibility on our services hosted with howard and their availability, we are deploying an instance of OneUpTime. We can then make a status page customized to our needs showcasing the status of our pages.

Here is an example of a status page from testing a deployment locally : 
![image](https://github.com/ai-cfia/howard/assets/73133692/73b11f0f-3b3d-4b66-988c-95911e20219b)
