### PR TITLE
issue #229: Update Secret Version for finesse-backend

### DIFF
--- a/kubernetes/aks/apps/finesse/base/finesse-secrets.yaml
+++ b/kubernetes/aks/apps/finesse/base/finesse-secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   name: finesse-secrets
   annotations:
     avp.kubernetes.io/path: "kv/data/finesse"
-    avp.kubernetes.io/secret-version: "9"
+    avp.kubernetes.io/secret-version: "11"
 stringData:
   AZURE_OPENAI_CHATGPT_DEPLOYMENT: <AZURE_OPENAI_CHATGPT_DEPLOYMENT>
   AZURE_OPENAI_GPT_DEPLOYMENT: <AZURE_OPENAI_GPT_DEPLOYMENT>


### PR DESCRIPTION
#229
- [x] changed `avp.kubernetes.io/secret-version` to `11`
