### PR TITLE
Improve resource management and security context for Finesse

### DIFF
--- a/kubernetes/aks/apps/finesse/internal/finesse-backend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/internal/finesse-backend-deployment.yml
@@ -13,10 +13,10 @@ spec:
       labels:
         app: finesse-backend
     spec:
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 3000
-      fsGroup: 2000
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: finesse-backend
           image: ghcr.io/ai-cfia/finesse-backend:main

--- a/kubernetes/aks/apps/finesse/internal/finesse-backend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/internal/finesse-backend-deployment.yml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: finesse-backend
     spec:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
       containers:
         - name: finesse-backend
           image: ghcr.io/ai-cfia/finesse-backend:main
@@ -33,7 +37,22 @@ spec:
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
-
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service
@@ -46,3 +65,13 @@ spec:
   ports:
     - protocol: TCP
       port: 8080
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: finesse-backend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: finesse-backend

--- a/kubernetes/aks/apps/finesse/internal/finesse-frontend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/internal/finesse-frontend-deployment.yml
@@ -13,10 +13,10 @@ spec:
       labels:
         app: finesse-frontend
     spec:
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 3000
-      fsGroup: 2000
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: finesse-frontend
           image: ghcr.io/ai-cfia/finesse-frontend:main

--- a/kubernetes/aks/apps/finesse/internal/finesse-frontend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/internal/finesse-frontend-deployment.yml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: finesse-frontend
     spec:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
       containers:
         - name: finesse-frontend
           image: ghcr.io/ai-cfia/finesse-frontend:main
@@ -25,6 +29,22 @@ spec:
               port: 3000
             initialDelaySeconds: 60
             periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service
@@ -37,3 +57,13 @@ spec:
   ports:
     - protocol: TCP
       port: 3000
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: finesse-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: finesse-frontend

--- a/kubernetes/aks/apps/finesse/public/finesse-backend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/public/finesse-backend-deployment.yml
@@ -13,10 +13,10 @@ spec:
       labels:
         app: finesse-backend
     spec:
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 3000
-      fsGroup: 2000
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: finesse-backend
           image: ghcr.io/ai-cfia/finesse-backend:main

--- a/kubernetes/aks/apps/finesse/public/finesse-backend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/public/finesse-backend-deployment.yml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: finesse-backend
     spec:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
       containers:
         - name: finesse-backend
           image: ghcr.io/ai-cfia/finesse-backend:main
@@ -33,7 +37,22 @@ spec:
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
-
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service
@@ -46,3 +65,13 @@ spec:
   ports:
     - protocol: TCP
       port: 8080
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: finesse-backend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: finesse-backend

--- a/kubernetes/aks/apps/finesse/public/finesse-frontend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/public/finesse-frontend-deployment.yml
@@ -13,10 +13,10 @@ spec:
       labels:
         app: finesse-frontend
     spec:
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 3000
-      fsGroup: 2000
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: finesse-frontend
           image: ghcr.io/ai-cfia/finesse-frontend:main

--- a/kubernetes/aks/apps/finesse/public/finesse-frontend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/public/finesse-frontend-deployment.yml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: finesse-frontend
     spec:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
       containers:
         - name: finesse-frontend
           image: ghcr.io/ai-cfia/finesse-frontend:main
@@ -25,6 +29,22 @@ spec:
               port: 3000
             initialDelaySeconds: 60
             periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service
@@ -37,3 +57,13 @@ spec:
   ports:
     - protocol: TCP
       port: 3000
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: finesse-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: finesse-frontend


### PR DESCRIPTION
This pull request updates the Kubernetes deployment manifests for both the backend and frontend services of the Finesse application.

changes: 
- Added security context to run as non-root with specific user and group IDs.
- Set resource requests and limits to manage CPU and memory usage effectively.
- Included a PodDisruptionBudget to ensure at least one pod is always available during disruptions. 

Testing:
- Load Testing with Locust:
  - Simulated 10 users making requests to the endpoint / on `https://finesse.inspection.alpha.canada.ca` for 1 minute.
  - Simulated 10 users making POST requests to the endpoint `/api/search/azure` on `https://finesse.inspection.alpha.canada.ca` with the payload {"query": "chien"} for 1 minute.
  - Used `kubectl top pods -n finesse` to monitor resource usage.

Summary : 
- Backend pods use approximately 0.010 CPU cores and 227.33 MB of memory.
- Frontend pods use approximately 0.002 CPU cores and 58.59 MB of memory.
- Resource requests and limits are based on observed usage during load testing.