### PR TITLE
Issue #296: Update ailab deployment with resource management and security context

### DIFF
--- a/kubernetes/aks/apps/ailab/base/deployment.yaml
+++ b/kubernetes/aks/apps/ailab/base/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       labels:
         app: ailab
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: ailab
           image: ghcr.io/ai-cfia/ai-cfia-ia-acia.github.io:main
@@ -24,6 +28,22 @@ spec:
               port: 3000
             initialDelaySeconds: 60
             periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service
@@ -36,3 +56,13 @@ spec:
   ports:
     - protocol: TCP
       port: 3000
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: finesse-frontend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: finesse-frontend


### PR DESCRIPTION
This pull request updates the Kubernetes deployment manifests for the ailab deployment

**changes:**
Added security context to run as non-root with specific user and group IDs.
Set resource requests and limits to manage CPU and memory usage effectively.
Included a PodDisruptionBudget to ensure at least one pod is always available during disruptions.

**Load Testing with Locust:**
- Simulated 10 users making requests to the endpoint / on https://ailab.inspection.alpha.canada.ca for 1 minute.
- Used kubectl top pods -n ailab to monitor resource usage.

**Summary :**
- Pod uses approximately 0.010 CPU cores and 120 MB of memory.
- Resource requests and limits are based on observed usage during load testing.