### PR TITLE
Issue #307: add revision history limit

### DIFF
--- a/kubernetes/aks/apps/ailab/base/deployment.yaml
+++ b/kubernetes/aks/apps/ailab/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ailab
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: ailab

--- a/kubernetes/aks/apps/fertiscan/base/fertiscan-backend-deployment.yaml
+++ b/kubernetes/aks/apps/fertiscan/base/fertiscan-backend-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: fertiscan-backend
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: fertiscan-backend

--- a/kubernetes/aks/apps/fertiscan/base/fertiscan-frontend-deployment.yaml
+++ b/kubernetes/aks/apps/fertiscan/base/fertiscan-frontend-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: fertiscan-frontend
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: fertiscan-frontend

--- a/kubernetes/aks/apps/finesse/internal/finesse-backend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/internal/finesse-backend-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   name: finesse-backend
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: finesse-backend

--- a/kubernetes/aks/apps/finesse/internal/finesse-frontend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/internal/finesse-frontend-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   name: finesse-frontend
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: finesse-frontend

--- a/kubernetes/aks/apps/finesse/public/finesse-backend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/public/finesse-backend-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   name: finesse-backend
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: finesse-backend

--- a/kubernetes/aks/apps/finesse/public/finesse-frontend-deployment.yml
+++ b/kubernetes/aks/apps/finesse/public/finesse-frontend-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   name: finesse-frontend
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: finesse-frontend

--- a/kubernetes/aks/apps/nachet/base/nachet-backend-deployment.yml
+++ b/kubernetes/aks/apps/nachet/base/nachet-backend-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: nachet
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: nachet-backend

--- a/kubernetes/aks/apps/nachet/base/nachet-frontend-deployment.yml
+++ b/kubernetes/aks/apps/nachet/base/nachet-frontend-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: nachet
 spec:
   replicas: 2
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: nachet-frontend


### PR DESCRIPTION
History limit set to 3 for ailab deployment to prevent the namespace to fill up with replicas from new image deployments.