### PR TITLE
Use new version of fertiscan backend

### DIFF
--- a/kubernetes/aks/apps/fertiscan/base/fertiscan-backend-deployment.yaml
+++ b/kubernetes/aks/apps/fertiscan/base/fertiscan-backend-deployment.yaml
@@ -33,7 +33,7 @@ spec:
                       - agent
       containers:
         - name: fertiscan-backend
-          image: ghcr.io/ai-cfia/fertiscan-backend:128-as-a-devops-i-want-to-have-a-healthy-image-of-fertiscan-backend
+          image: ghcr.io/ai-cfia/fertiscan-backend:app-on-0.0.0.0
           imagePullPolicy: Always
           envFrom:
             - secretRef:


### PR DESCRIPTION
Changes have been made to fertiscan backend (localhost to 0.0.0.0) and we need to use thoses changes on the deployment