### PR TITLE
issue #422: update fertiscan backend preview secrets version to 27 

### DIFF
--- a/kubernetes/aks/apps/fertiscan-preview/base/fertiscan-secrets.yaml
+++ b/kubernetes/aks/apps/fertiscan-preview/base/fertiscan-secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fertiscan-backend-preview-secrets
   annotations:
     avp.kubernetes.io/path: "kv/data/fertiscan/backend"
-    avp.kubernetes.io/secret-version: "24"
+    avp.kubernetes.io/secret-version: "26"
 stringData:
   AZURE_API_ENDPOINT: <AZURE_API_ENDPOINT>
   AZURE_API_KEY: <AZURE_API_KEY>

--- a/kubernetes/aks/apps/fertiscan-preview/base/fertiscan-secrets.yaml
+++ b/kubernetes/aks/apps/fertiscan-preview/base/fertiscan-secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fertiscan-backend-preview-secrets
   annotations:
     avp.kubernetes.io/path: "kv/data/fertiscan/backend"
-    avp.kubernetes.io/secret-version: "26"
+    avp.kubernetes.io/secret-version: "27"
 stringData:
   AZURE_API_ENDPOINT: <AZURE_API_ENDPOINT>
   AZURE_API_KEY: <AZURE_API_KEY>


### PR DESCRIPTION
fix a url breaking char in postgres dsn